### PR TITLE
ENG-346 removes support for properties in default widget 

### DIFF
--- a/src/main/java/org/entando/kubernetes/model/bundle/descriptor/ComponentSpecDescriptor.java
+++ b/src/main/java/org/entando/kubernetes/model/bundle/descriptor/ComponentSpecDescriptor.java
@@ -1,5 +1,6 @@
 package org.entando.kubernetes.model.bundle.descriptor;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
 import java.util.List;
 import lombok.Data;
 
@@ -10,10 +11,18 @@ public class ComponentSpecDescriptor {
     private List<String> widgets;
     private List<String> fragments;
     private List<String> pages;
-    private List<String> pageModels;
+    private List<String> pageTemplates;
     private List<String> contentTypes;
-    private List<String> contentModels;
+    private List<String> contentTemplates;
     private List<LabelDescriptor> labels;
 
+    @JsonSetter(value = "contentModels")
+    private void setContentModels(List<String> contentModels) {
+        this.contentTemplates = contentModels;
+    }
 
+    @JsonSetter(value = "pageModels")
+    private void setPageModels(List<String> contentModels) {
+        this.pageTemplates = contentModels;
+    }
 }

--- a/src/main/java/org/entando/kubernetes/model/bundle/descriptor/DefaultWidgetDescriptor.java
+++ b/src/main/java/org/entando/kubernetes/model/bundle/descriptor/DefaultWidgetDescriptor.java
@@ -1,6 +1,6 @@
 package org.entando.kubernetes.model.bundle.descriptor;
 
-import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,8 +12,8 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DefaultWidgetDescriptor {
 
     private String code;
-    private Map<String, String> properties;
 }

--- a/src/main/java/org/entando/kubernetes/model/bundle/processor/ContentTemplateProcessor.java
+++ b/src/main/java/org/entando/kubernetes/model/bundle/processor/ContentTemplateProcessor.java
@@ -41,7 +41,7 @@ public class ContentTemplateProcessor implements ComponentProcessor<ContentTempl
         try {
             BundleDescriptor descriptor = npr.readBundleDescriptor();
             List<String> contentModelsDescriptor = ofNullable(descriptor.getComponents())
-                    .map(ComponentSpecDescriptor::getContentModels)
+                    .map(ComponentSpecDescriptor::getContentTemplates)
                     .orElse(new ArrayList<>());
 
             List<Installable<ContentTemplateDescriptor>> installables = new LinkedList<>();

--- a/src/main/java/org/entando/kubernetes/model/bundle/processor/PageTemplateProcessor.java
+++ b/src/main/java/org/entando/kubernetes/model/bundle/processor/PageTemplateProcessor.java
@@ -41,7 +41,7 @@ public class PageTemplateProcessor implements ComponentProcessor<PageTemplateDes
         try {
             BundleDescriptor descriptor = npr.readBundleDescriptor();
             List<String> pageTemplatesDescriptor = ofNullable(descriptor.getComponents())
-                    .map(ComponentSpecDescriptor::getPageModels)
+                    .map(ComponentSpecDescriptor::getPageTemplates)
                     .orElse(Collections.emptyList());
 
             List<Installable<PageTemplateDescriptor>> installables = new LinkedList<>();

--- a/src/main/java/org/entando/kubernetes/model/entandocore/EntandoCoreFrameDefaultWidget.java
+++ b/src/main/java/org/entando/kubernetes/model/entandocore/EntandoCoreFrameDefaultWidget.java
@@ -15,10 +15,8 @@ import org.entando.kubernetes.model.bundle.descriptor.DefaultWidgetDescriptor;
 @AllArgsConstructor
 public class EntandoCoreFrameDefaultWidget {
     String code;
-    Map<String, String> properties;
 
     public EntandoCoreFrameDefaultWidget(DefaultWidgetDescriptor defaultWidgetDescriptor) {
         this.code = defaultWidgetDescriptor.getCode();
-        this.properties = defaultWidgetDescriptor.getProperties();
     }
 }

--- a/src/test/java/org/entando/kubernetes/client/model/bundle/processor/PageTemplateProcessorTest.java
+++ b/src/test/java/org/entando/kubernetes/client/model/bundle/processor/PageTemplateProcessorTest.java
@@ -51,7 +51,7 @@ public class PageTemplateProcessorTest {
         job.setComponentId("my-component-id");
 
         ComponentSpecDescriptor spec = new ComponentSpecDescriptor();
-        spec.setPageModels(Collections.singletonList("/pagemodels/my_page_model_descriptor.yaml"));
+        spec.setPageTemplates(Collections.singletonList("/pagemodels/my_page_model_descriptor.yaml"));
 
         PageTemplateDescriptor pageTe = MAPPER.readValue(
                 readFromFile("bundle/pagemodels/my_page_model_descriptor.yaml"),
@@ -92,13 +92,10 @@ public class PageTemplateProcessorTest {
         assertThat(breadCrumbFrame.getDescription()).isEqualTo("Breadcrumb");
         assertThat(breadCrumbFrame.getDefaultWidget()).isNotNull();
         assertThat(breadCrumbFrame.getDefaultWidget().getCode()).isEqualTo("breadcrumb");
-        assertThat(breadCrumbFrame.getDefaultWidget().getProperties()).isNull();
 
         assertThat(bodyFrame.getDescription()).isEqualTo("Body");
         assertThat(bodyFrame.getDefaultWidget()).isNotNull();
         assertThat(bodyFrame.getDefaultWidget().getCode()).isEqualTo("my-widget");
-        assertThat(bodyFrame.getDefaultWidget().getProperties()).isNotNull();
-        assertThat(bodyFrame.getDefaultWidget().getProperties().get("title")).isEqualTo("My fantastic widget");
 
         assertThat(footerFrame.getDescription()).isEqualTo("Footer");
         assertThat(footerFrame.getDefaultWidget()).isNull();

--- a/src/test/java/org/entando/kubernetes/client/model/entandocore/EntandoCorePageTemplateTest.java
+++ b/src/test/java/org/entando/kubernetes/client/model/entandocore/EntandoCorePageTemplateTest.java
@@ -31,7 +31,6 @@ public class EntandoCorePageTemplateTest {
         assertThat(ecpt.getConfiguration().getFrames().get(0).getSketch())
                 .isEqualToComparingFieldByField(new EntandoCoreSketchDescriptor(0, 0, 11, 0));
         assertThat(ecpt.getConfiguration().getFrames().get(0).getDefaultWidget().getCode()).isEqualTo("default-widget");
-        assertThat(ecpt.getConfiguration().getFrames().get(0).getDefaultWidget().getProperties().get("title")).isEqualTo("default");
         assertThat(ecpt.getTitles().keySet()).containsExactlyInAnyOrder("it", "en");
         assertThat(ecpt.getTitles().values()).containsExactlyInAnyOrder("Il mio template di pagina", "My page template");
     }
@@ -51,7 +50,6 @@ public class EntandoCorePageTemplateTest {
                 .sketch(new SketchDescriptor(0, 0, 11, 0))
                 .defaultWidget(DefaultWidgetDescriptor.builder()
                         .code("default-widget")
-                        .properties(properties)
                         .build())
                 .build();
 


### PR DESCRIPTION
Removes support for properties in the default widget descriptor as as they are not exposed via the Entando Core API