### PR TITLE
ENG-958 ecr presents wrong latest bundle version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <entando.k8s.custom.model.version>6.0.65</entando.k8s.custom.model.version>
         <tomcat-embed.version>9.0.37</tomcat-embed.version>
         <awaitility.version>4.0.1</awaitility.version>
+        <java.semver>0.9.0</java.semver>
 
         <!-- plugin  versions -->
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -358,6 +359,11 @@
             <artifactId>spring-security-test</artifactId>
             <version>5.2.1.RELEASE</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.zafarkhaja</groupId>
+            <artifactId>java-semver</artifactId>
+            <version>${java.semver}</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/org/entando/kubernetes/model/bundle/EntandoBundle.java
+++ b/src/main/java/org/entando/kubernetes/model/bundle/EntandoBundle.java
@@ -1,6 +1,7 @@
 package org.entando.kubernetes.model.bundle;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.github.zafarkhaja.semver.Version;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -37,7 +38,7 @@ public class EntandoBundle {
     }
 
     public Optional<EntandoBundleVersion> getLatestVersion() {
-        return this.versions.stream().max(Comparator.comparing(EntandoBundleVersion::getVersion));
+        return this.versions.stream().max(Comparator.comparing(EntandoBundleVersion::getSemVersion));
     }
 
 }

--- a/src/main/java/org/entando/kubernetes/model/bundle/EntandoBundleVersion.java
+++ b/src/main/java/org/entando/kubernetes/model/bundle/EntandoBundleVersion.java
@@ -26,8 +26,7 @@ public class EntandoBundleVersion {
     //private ZonedDateTime timestamp;
 
     public static EntandoBundleVersion fromEntity(EntandoDeBundleTag tag) {
-        return EntandoBundleVersion.builder()
-                .version(tag.getVersion())
+        return new EntandoBundleVersion().setVersion(tag.getVersion());
                 //.timestamp() TODO how to read from k8s custom model?
     }
 

--- a/src/main/java/org/entando/kubernetes/model/bundle/EntandoBundleVersion.java
+++ b/src/main/java/org/entando/kubernetes/model/bundle/EntandoBundleVersion.java
@@ -3,6 +3,7 @@ package org.entando.kubernetes.model.bundle;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.github.zafarkhaja.semver.Version;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,6 +20,7 @@ public class EntandoBundleVersion {
 
     private String version;
     @JsonIgnore
+    @Setter(AccessLevel.NONE)
     private Version semVersion;
     //private ZonedDateTime timestamp;
 
@@ -33,4 +35,5 @@ public class EntandoBundleVersion {
         this.semVersion = Version.valueOf(version.replaceAll("^v", ""));
         return this;
     }
+
 }

--- a/src/main/java/org/entando/kubernetes/model/bundle/EntandoBundleVersion.java
+++ b/src/main/java/org/entando/kubernetes/model/bundle/EntandoBundleVersion.java
@@ -1,26 +1,36 @@
 package org.entando.kubernetes.model.bundle;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.github.zafarkhaja.semver.Version;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.Accessors;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 @JsonInclude
+@Accessors(chain = true)
 public class EntandoBundleVersion {
+
     private String version;
+    @JsonIgnore
+    private Version semVersion;
     //private ZonedDateTime timestamp;
 
     public static EntandoBundleVersion fromEntity(String version) {
-        return EntandoBundleVersion.builder()
-                .version(version)
+        return new EntandoBundleVersion()
+                .setVersion(version);
                 //.timestamp() TODO how to read from k8s custom model?
-                .build();
+    }
+
+    public EntandoBundleVersion setVersion(String version) {
+        this.version = version;
+        this.semVersion = Version.valueOf(version.replaceAll("^v", ""));
+        return this;
     }
 }

--- a/src/test/java/org/entando/kubernetes/model/bundle/EntandoBundleTest.java
+++ b/src/test/java/org/entando/kubernetes/model/bundle/EntandoBundleTest.java
@@ -9,11 +9,11 @@ import org.junit.jupiter.api.Test;
 
 class EntandoBundleTest {
 
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
 
     @Test
-    void testGetLatestVersionWithStartingV() throws IOException {
+    void testGetLatestVersionWithLeadingV() throws IOException {
 
         EntandoBundle entandoBundle = objectMapper.readValue(new File("src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json"), EntandoBundle.class);
 
@@ -21,34 +21,34 @@ class EntandoBundleTest {
     }
 
     @Test
-    void testGetLatestVersionWithoutStartingV() throws IOException {
+    void testGetLatestVersionWithoutLeadingV() throws IOException {
 
         EntandoBundle entandoBundle = objectMapper.readValue(new File("src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json"), EntandoBundle.class);
         // remove the starting v from versions
         entandoBundle.getVersions()
-                .forEach(this::removeStartingV);
+                .forEach(this::removeLeadingV);
 
         assertEquals("0.0.13", entandoBundle.getLatestVersion().get().getVersion());
     }
 
     @Test
-    void testGetLatestVersionMixingStartingVWithFinalElementWithV() throws IOException {
+    void testGetLatestVersionMixingLeadingVWithFinalElementWithV() throws IOException {
 
         EntandoBundle entandoBundle = objectMapper.readValue(new File("src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json"), EntandoBundle.class);
         // remove some starting v from versions
-        this.removeStartingV(entandoBundle.getVersions().get(4));
-        this.removeStartingV(entandoBundle.getVersions().get(6));
+        this.removeLeadingV(entandoBundle.getVersions().get(4));
+        this.removeLeadingV(entandoBundle.getVersions().get(6));
 
         assertEquals("v0.0.13", entandoBundle.getLatestVersion().get().getVersion());
     }
 
     @Test
-    void testGetLatestVersionMixingStartingVWithFinalElementWithoutV() throws IOException {
+    void testGetLatestVersionMixingLeadingVWithFinalElementWithoutV() throws IOException {
 
         EntandoBundle entandoBundle = objectMapper.readValue(new File("src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json"), EntandoBundle.class);
         // remove some starting v from versions
-        this.removeStartingV(entandoBundle.getVersions().get(4));
-        this.removeStartingV(entandoBundle.getVersions().get(12));
+        this.removeLeadingV(entandoBundle.getVersions().get(4));
+        this.removeLeadingV(entandoBundle.getVersions().get(12));
 
         assertEquals("0.0.13", entandoBundle.getLatestVersion().get().getVersion());
     }
@@ -63,7 +63,7 @@ class EntandoBundleTest {
     }
 
     @Test
-    void testGetLatestVersionWithAlphaAndStartingV() throws IOException {
+    void testGetLatestVersionWithAlphaAndLeadingV() throws IOException {
 
         EntandoBundle entandoBundle = objectMapper.readValue(new File("src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json"), EntandoBundle.class);
         entandoBundle.getVersions().add(new EntandoBundleVersion().setVersion("v0.0.14-alpha"));
@@ -86,7 +86,7 @@ class EntandoBundleTest {
      *
      * @param entandoBundleVersion
      */
-    private void removeStartingV(EntandoBundleVersion entandoBundleVersion) {
+    private void removeLeadingV(EntandoBundleVersion entandoBundleVersion) {
         entandoBundleVersion.setVersion(entandoBundleVersion.getVersion().replaceAll("^v", ""));
     }
 

--- a/src/test/java/org/entando/kubernetes/model/bundle/EntandoBundleTest.java
+++ b/src/test/java/org/entando/kubernetes/model/bundle/EntandoBundleTest.java
@@ -1,0 +1,93 @@
+package org.entando.kubernetes.model.bundle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class EntandoBundleTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+
+    @Test
+    void testGetLatestVersionWithStartingV() throws IOException {
+
+        EntandoBundle entandoBundle = objectMapper.readValue(new File("src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json"), EntandoBundle.class);
+
+        assertEquals("v0.0.13", entandoBundle.getLatestVersion().get().getVersion());
+    }
+
+    @Test
+    void testGetLatestVersionWithoutStartingV() throws IOException {
+
+        EntandoBundle entandoBundle = objectMapper.readValue(new File("src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json"), EntandoBundle.class);
+        // remove the starting v from versions
+        entandoBundle.getVersions()
+                .forEach(this::removeStartingV);
+
+        assertEquals("0.0.13", entandoBundle.getLatestVersion().get().getVersion());
+    }
+
+    @Test
+    void testGetLatestVersionMixingStartingVWithFinalElementWithV() throws IOException {
+
+        EntandoBundle entandoBundle = objectMapper.readValue(new File("src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json"), EntandoBundle.class);
+        // remove some starting v from versions
+        this.removeStartingV(entandoBundle.getVersions().get(4));
+        this.removeStartingV(entandoBundle.getVersions().get(6));
+
+        assertEquals("v0.0.13", entandoBundle.getLatestVersion().get().getVersion());
+    }
+
+    @Test
+    void testGetLatestVersionMixingStartingVWithFinalElementWithoutV() throws IOException {
+
+        EntandoBundle entandoBundle = objectMapper.readValue(new File("src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json"), EntandoBundle.class);
+        // remove some starting v from versions
+        this.removeStartingV(entandoBundle.getVersions().get(4));
+        this.removeStartingV(entandoBundle.getVersions().get(12));
+
+        assertEquals("0.0.13", entandoBundle.getLatestVersion().get().getVersion());
+    }
+
+    @Test
+    void testGetLatestVersionWithAlpha() throws IOException {
+
+        EntandoBundle entandoBundle = objectMapper.readValue(new File("src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json"), EntandoBundle.class);
+        entandoBundle.getVersions().add(new EntandoBundleVersion().setVersion("0.0.14-alpha"));
+
+        assertEquals("0.0.14-alpha", entandoBundle.getLatestVersion().get().getVersion());
+    }
+
+    @Test
+    void testGetLatestVersionWithAlphaAndStartingV() throws IOException {
+
+        EntandoBundle entandoBundle = objectMapper.readValue(new File("src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json"), EntandoBundle.class);
+        entandoBundle.getVersions().add(new EntandoBundleVersion().setVersion("v0.0.14-alpha"));
+
+        assertEquals("v0.0.14-alpha", entandoBundle.getLatestVersion().get().getVersion());
+    }
+
+    @Test
+    void testGetLatestVersionWithAlphaAndStable() throws IOException {
+
+        EntandoBundle entandoBundle = objectMapper.readValue(new File("src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json"), EntandoBundle.class);
+        entandoBundle.getVersions().add(new EntandoBundleVersion().setVersion("v0.0.14-alpha"));
+        entandoBundle.getVersions().add(new EntandoBundleVersion().setVersion("v0.0.14"));
+
+        assertEquals("v0.0.14", entandoBundle.getLatestVersion().get().getVersion());
+    }
+
+
+    /**
+     *
+     * @param entandoBundleVersion
+     */
+    private void removeStartingV(EntandoBundleVersion entandoBundleVersion) {
+        entandoBundleVersion.setVersion(entandoBundleVersion.getVersion().replaceAll("^v", ""));
+    }
+
+}

--- a/src/test/java/org/entando/kubernetes/model/bundle/EntandoBundleTest.java
+++ b/src/test/java/org/entando/kubernetes/model/bundle/EntandoBundleTest.java
@@ -1,10 +1,15 @@
 package org.entando.kubernetes.model.bundle;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.zafarkhaja.semver.Version;
 import java.io.File;
 import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 class EntandoBundleTest {
@@ -81,6 +86,23 @@ class EntandoBundleTest {
         assertEquals("v0.0.14", entandoBundle.getLatestVersion().get().getVersion());
     }
 
+    @Test
+    void testExpectedVersionSort() throws IOException {
+
+        EntandoBundle entandoBundle = objectMapper.readValue(new File("src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json"), EntandoBundle.class);
+        entandoBundle.getVersions().add(new EntandoBundleVersion().setVersion("v0.0.14-beta"));
+        entandoBundle.getVersions().add(new EntandoBundleVersion().setVersion("v0.0.14-alpha"));
+        entandoBundle.getVersions().add(new EntandoBundleVersion().setVersion("v0.0.14-rc.1"));
+        entandoBundle.getVersions().add(new EntandoBundleVersion().setVersion("v0.0.14-rc.2"));
+        entandoBundle.getVersions().add(new EntandoBundleVersion().setVersion("v0.0.14-snapshot"));
+        entandoBundle.getVersions().add(new EntandoBundleVersion().setVersion("v0.0.14"));
+
+        List<String> sortedVersions = entandoBundle.getVersions().stream()
+                .sorted(Comparator.comparing(EntandoBundleVersion::getSemVersion, Version::compareTo).reversed())
+                .map(EntandoBundleVersion::getVersion)
+                .collect(Collectors.toList());
+        assertThat(sortedVersions).startsWith("v0.0.14", "v0.0.14-snapshot", "v0.0.14-rc.2", "v0.0.14-rc.1", "v0.0.14-beta", "v0.0.14-alpha");
+    }
 
     /**
      *

--- a/src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json
+++ b/src/test/resources/payloads/k8s-svc/bundles/bundle_with_versions.json
@@ -1,0 +1,50 @@
+{
+  "code":"cool-bundle",
+  "title":"Nice bundle",
+  "description":"Great bundle",
+  "thumbnail":null,
+  "componentTypes":null,
+  "installedJob":null,
+  "lastJob":null,
+  "versions": [
+    {
+      "version": "v0.0.1"
+    },
+    {
+      "version": "v0.0.2"
+    },
+    {
+      "version": "v0.0.3"
+    },
+    {
+      "version": "v0.0.4"
+    },
+    {
+      "version": "v0.0.5"
+    },
+    {
+      "version": "v0.0.6"
+    },
+    {
+      "version": "v0.0.7"
+    },
+    {
+      "version": "v0.0.8"
+    },
+    {
+      "version": "v0.0.9"
+    },
+    {
+      "version": "v0.0.10"
+    },
+    {
+      "version": "v0.0.11"
+    },
+    {
+      "version": "v0.0.12"
+    },
+    {
+      "version": "v0.0.13"
+    }
+  ]
+}


### PR DESCRIPTION
I have added one more field for the version in the `EntandoBundleVersion.class`
This field type is the `Version` one from the java-semver library.
I would have liked to remove the String one but the lib Version class strictly respects the Semantic Versioning rules and it doesn't accept the leading `v` char in the version name.
I have removed the @Builder annotation from the EntandoBundleVersion.class because the semVer Version field is instantiated in the String version setter method.
I also disabled the setSemVersion method Lombok generation for the same reason.