### PR TITLE
Eng 1288 moves labels into dedicated files

### DIFF
--- a/src/main/java/org/entando/kubernetes/model/bundle/descriptor/ComponentSpecDescriptor.java
+++ b/src/main/java/org/entando/kubernetes/model/bundle/descriptor/ComponentSpecDescriptor.java
@@ -16,7 +16,7 @@ public class ComponentSpecDescriptor {
     private List<String> contentTypes;
     private List<String> contentTemplates;
     private List<String> groups;
-    private List<LabelDescriptor> labels;
+    private List<String> labels;
 
     @JsonSetter(value = "contentModels")
     private void setContentModels(List<String> contentModels) {

--- a/src/main/java/org/entando/kubernetes/model/bundle/processor/LabelProcessor.java
+++ b/src/main/java/org/entando/kubernetes/model/bundle/processor/LabelProcessor.java
@@ -3,9 +3,9 @@ package org.entando.kubernetes.model.bundle.processor;
 import static java.util.Optional.ofNullable;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Service;
 
 /**
  * Processor to create Labels.
- *
  */
 @Slf4j
 @Service
@@ -42,13 +41,16 @@ public class LabelProcessor implements ComponentProcessor<LabelDescriptor> {
         try {
             BundleDescriptor descriptor = npr.readBundleDescriptor();
 
-            final Optional<List<LabelDescriptor>> labelDescriptors = ofNullable(descriptor.getComponents())
-                    .map(ComponentSpecDescriptor::getLabels);
+            final List<String> labelDescriptorFiles = ofNullable(descriptor.getComponents())
+                    .map(ComponentSpecDescriptor::getLabels)
+                    .orElse(Collections.emptyList());
+
             final List<Installable<LabelDescriptor>> installables = new LinkedList<>();
 
-            if (labelDescriptors.isPresent()) {
-                for (final LabelDescriptor labelDescriptor : labelDescriptors.get()) {
-                    installables.add(new LabelInstallable(engineService, labelDescriptor));
+            for (String ldf : labelDescriptorFiles) {
+                List<LabelDescriptor> labelDescriptorList = npr.readListOfDescriptorFile(ldf, LabelDescriptor.class);
+                for (LabelDescriptor ld : labelDescriptorList) {
+                    installables.add(new LabelInstallable(engineService, ld));
                 }
             }
 

--- a/src/test/java/org/entando/kubernetes/model/bundle/EntandoBundleReaderTest.java
+++ b/src/test/java/org/entando/kubernetes/model/bundle/EntandoBundleReaderTest.java
@@ -19,6 +19,7 @@ import org.entando.kubernetes.model.bundle.descriptor.CategoryDescriptor;
 import org.entando.kubernetes.model.bundle.descriptor.Descriptor;
 import org.entando.kubernetes.model.bundle.descriptor.FileDescriptor;
 import org.entando.kubernetes.model.bundle.descriptor.GroupDescriptor;
+import org.entando.kubernetes.model.bundle.descriptor.LabelDescriptor;
 import org.entando.kubernetes.model.bundle.descriptor.WidgetDescriptor;
 import org.entando.kubernetes.model.bundle.descriptor.WidgetDescriptor.ConfigUIDescriptor;
 import org.entando.kubernetes.model.bundle.installable.Installable;
@@ -107,6 +108,17 @@ public class EntandoBundleReaderTest {
         assertThat(cd.get(0).getParentCode()).isEqualTo("home");
         assertThat(cd.get(0).getTitles()).containsEntry("it", "La mia categoria");
         assertThat(cd.get(0).getTitles()).containsEntry("en", "My own category");
+    }
+
+    @Test
+    public void shouldReadLabelsFromDedicatedFile() throws IOException {
+        List<LabelDescriptor> ld = bundleReader
+                .readListOfDescriptorFile("labels/labels.yaml", LabelDescriptor.class);
+        assertThat(ld).hasSize(1);
+        assertThat(ld.get(0).getKey()).isEqualTo("HELLO");
+        assertThat(ld.get(0).getTitles()).containsEntry("it", "Mio Titolo");
+        assertThat(ld.get(0).getTitles()).containsEntry("en", "My Title");
+
     }
 
     @Test

--- a/src/test/java/org/entando/kubernetes/model/bundle/processor/LabelProcessorTest.java
+++ b/src/test/java/org/entando/kubernetes/model/bundle/processor/LabelProcessorTest.java
@@ -50,8 +50,12 @@ public class LabelProcessorTest {
 
         final ComponentSpecDescriptor spec = new ComponentSpecDescriptor();
         final BundleDescriptor descriptor = new BundleDescriptor("my-component", "desc", spec);
-        spec.setLabels(singletonList(new LabelDescriptor("HELLO", singletonMap("en", "Hello"))));
+        spec.setLabels(singletonList("labels/labels.yaml"));
+
         when(bundleReader.readBundleDescriptor()).thenReturn(descriptor);
+        when(bundleReader.readListOfDescriptorFile("labels/labels.yaml", LabelDescriptor.class))
+                .thenReturn(singletonList(new LabelDescriptor("HELLO", singletonMap("en", "Hello"))));
+
 
         final List<? extends Installable> installables = processor.process(bundleReader);
 

--- a/src/test/resources/bundle/descriptor.yaml
+++ b/src/test/resources/bundle/descriptor.yaml
@@ -33,7 +33,5 @@ components:
     - categories/my-category.yaml
 
   labels:
-    - key: HELLO
-      titles:
-        it: Mio Titolo
-        en: My Title
+    - labels/labels.yaml
+

--- a/src/test/resources/bundle/labels/labels.yaml
+++ b/src/test/resources/bundle/labels/labels.yaml
@@ -1,0 +1,4 @@
+- key: HELLO
+  titles:
+    it: Mio Titolo
+    en: My Title


### PR DESCRIPTION
This PR moves the labels reading from the descriptor.yaml to dedicated files referenced as strings in the descriptor.yaml as all the other components