### PR TITLE
ENG-1364 updated content type attribute descriptor with latest changes on core

### DIFF
--- a/src/main/java/org/entando/kubernetes/model/bundle/descriptor/ContentTypeAttribute.java
+++ b/src/main/java/org/entando/kubernetes/model/bundle/descriptor/ContentTypeAttribute.java
@@ -1,6 +1,7 @@
 package org.entando.kubernetes.model.bundle.descriptor;
 
 import java.util.List;
+import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,7 +11,7 @@ public class ContentTypeAttribute {
 
     private String code;
     private String type;
-    private String name;
+    private Map<String, String> names;
     private List<Role> roles;
     private List<String> disablingCodes;
     private Boolean mandatory;

--- a/src/test/resources/bundle/contenttypes/my_content_type_descriptor.yaml
+++ b/src/test/resources/bundle/contenttypes/my_content_type_descriptor.yaml
@@ -7,7 +7,9 @@ defaultContentModelList:
 attributes:
   - code: title
     type: Text
-    name: Title
+    names:
+      en: Title
+      it: Titolo
     roles:
       - code: jacms:title
         descr: The main title of a Content
@@ -50,7 +52,9 @@ attributes:
         ognlExpression: string
   - code: attachments
     type: Monolist
-    name:
+    names:
+      en: Title
+      it: Titolo
     roles: []
     disablingCodes: []
     mandatory: false
@@ -85,7 +89,9 @@ attributes:
     nestedAttribute:
       code: attach
       type: Attach
-      name:
+      names:
+        en: Title
+        it: Titolo
       roles: []
       disablingCodes: []
       mandatory: false
@@ -122,7 +128,9 @@ attributes:
     compositeAttributes:
   - code: composite
     type: Composite
-    name: Testo
+    names:
+      en: Test
+      it: Testo
     roles:
     disablingCodes:
     mandatory: false
@@ -158,7 +166,9 @@ attributes:
     compositeAttributes:
       - code: comp_img
         type: Image
-        name: Testo
+        names:
+          en: Test
+          it: Testo
         roles:
         disablingCodes:
         mandatory: false


### PR DESCRIPTION
`name` was replaced by an i18n map called `names`.

Related to PR on entando-engine:
 - https://github.com/entando/entando-engine/pull/40