### PR TITLE
ENG-1422: Remove java execution option UseCGroupMemoryLimitForHeap as…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ COPY pom.xml target/lib* /opt/lib/
 COPY target/entando-component-manager.jar /opt/app.jar
 WORKDIR /opt
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar", "app.jar"]
+CMD ["java", "-XX:MaxRAMPercentage=80.0", "-jar", "app.jar"]


### PR DESCRIPTION
… it's no more supported in java 11