### PR TITLE
ENG-1711 updated to rhel UBI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-slim
+FROM registry.access.redhat.com/ubi8/openjdk-11
 ENV PORT=8080 \
     CLASSPATH=/opt/lib \
     USER_NAME=root \
@@ -6,18 +6,23 @@ ENV PORT=8080 \
     NSS_WRAPPER_GROUP=/tmp/group
 
 COPY passwd.template entrypoint.sh /
+USER root
+RUN microdnf install -y yum
 
 RUN chmod -Rf g+rw /opt && \
     touch ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP} && \
     chgrp 0 ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP} && \
     chmod g+rw ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP} && \
-    apt-get update && apt-get upgrade -y && \
-    apt-get install -y git curl gpg tar gettext-base libnss-wrapper && \
-    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
-    apt-get install -y git-lfs && git lfs install && \
-    rm -rf /var/lib/apt/lists/*
+    yum update -y && yum upgrade -y && \
+    yum install -y git curl gpg tar gettext nss_wrapper && \
+    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash && \
+    yum install -y git-lfs && git lfs install && \
+    rm -rf /var/cache/yum
+
+USER 185
 
 EXPOSE 8080
+
 
 # copy pom.xml and wildcards to avoid this command failing if there's no target/lib directory
 COPY pom.xml target/lib* /opt/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,16 @@
 FROM registry.access.redhat.com/ubi8/openjdk-11
+
+### Required OpenShift Labels
+LABEL name="Entando Component Manager" \
+      maintainer="dev@entando.com" \
+      vendor="Entando Inc." \
+      version="6.3.0" \
+      release="6.3.0" \
+      summary="Entando Component Manager for Entando Component Repository" \
+      description="The component manager provides apis and infrastructure to support the deployment and development of bundles to an Entando Application."
+
+COPY target/generated-resources/licenses /licenses
+
 ENV PORT=8080 \
     CLASSPATH=/opt/lib \
     USER_NAME=root \
@@ -6,6 +18,8 @@ ENV PORT=8080 \
     NSS_WRAPPER_GROUP=/tmp/group
 
 COPY passwd.template entrypoint.sh /
+
+
 USER root
 RUN microdnf install -y yum
 

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,19 @@
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>2.8.2</version>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <id>download-licenses</id>
+                        <goals>
+                            <goal>download-licenses</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <reporting>
@@ -277,6 +290,9 @@
                     </reportSet>
                 </reportSets>
             </plugin>
+
+
+
         </plugins>
     </reporting>
 </project>


### PR DESCRIPTION
Smoke tested with:
 entando-component-manager: >-
    {"version":"ubi-6.3.0","executable-type":"jvm","registry":"docker.io","organization":"jwhite101"}

Still needs a deeper ECR test in particular