### PR TITLE
ENG-2241 db migration for mysql compatibility issues fix

### DIFF
--- a/src/main/resources/db/changelog/changes/20190809112455-create-schema.yaml
+++ b/src/main/resources/db/changelog/changes/20190809112455-create-schema.yaml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 20190809112455
       author: l.cherubin@entando.com
+      validCheckSum: 8:6639268899116f73134e8f27fc3997a6
       preConditions:
         - onFail: MARK_RAN
           not:
@@ -137,7 +138,7 @@ databaseChangeLog:
                     references: entando_bundle_jobs(id)
               - column:
                   name: last_update
-                  type: TIMESTAMP WITHOUT TIME ZONE
+                  type: TIMESTAMP
               - column:
                   name: metadata
                   type: VARCHAR(255)

--- a/src/main/resources/db/changelog/changes/20201105193500-update-schema.yaml
+++ b/src/main/resources/db/changelog/changes/20201105193500-update-schema.yaml
@@ -2,12 +2,13 @@ databaseChangeLog:
   - changeSet:
       id: 20201105193500
       author: ffleandro
+      validCheckSum: 8:c054fd9a924cfc4fdcafe359dff7c01d
       changes:
         - addColumn:
             columns:
               - column:
                   name: action
-                  type: TEXT
+                  type: varchar(16)
                   defaultValue: CREATE
                   constraints:
                     nullable: false

--- a/src/main/resources/db/changelog/changes/20210413193701-mysql-compatibity-issues-fix.yaml
+++ b/src/main/resources/db/changelog/changes/20210413193701-mysql-compatibity-issues-fix.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 20210413193701
+      author: l.corsetti
+      changes:
+        - modifyDataType:
+            tableName: entando_bundle_component_jobs
+            columnName: action
+            newDataType: varchar(16)
+        - modifyDataType:
+            tableName: installed_entando_bundles
+            columnName: last_update
+            newDataType: TIMESTAMP


### PR DESCRIPTION
changed migration scripts according to mysql specifications
workaround to overcome changeset checksum validation using validCheckSum property
added new migration file in order to align already applied migrations