### PR TITLE
ENG-4880 Add crane login to saveBundleStrategy

### DIFF
--- a/src/main/java/org/entando/kubernetes/model/bundle/downloader/DockerBundleDownloader.java
+++ b/src/main/java/org/entando/kubernetes/model/bundle/downloader/DockerBundleDownloader.java
@@ -91,6 +91,9 @@ public class DockerBundleDownloader extends BundleDownloader {
             String fullyQualifiedImageUrl = generateFullyQualifiedWithTag(tag);
             ImageValidator.parse(fullyQualifiedImageUrl).isValidOrThrow(ERROR_WHILE_DOWNLOADING_IMAGE);
 
+            if (useCredentials()) {
+                getCredentials(fullyQualifiedImageUrl).ifPresent(this::doCraneAuthLogin);
+            }
             final String imageDigest = craneCommand.getImageDigest(fullyQualifiedImageUrl);
             saveContainerImage(fullyQualifiedImageUrl, targetPath);
             log.info("Docker image saved");


### PR DESCRIPTION
Add `doCraneAuthLogin` to the `saveBundleStrategy` method in DockerBundleDownloader.java

This is necessary to install bundles from a private repository.